### PR TITLE
added architecture detection and flag switching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,27 @@ ifneq '$(DEFAULT_DB_DIR)' ''
 	DBDIR := -D'CONDA_DB_DIR="$(DEFAULT_DB_DIR)"'
 endif
 
-CPPFLAGS = -std=gnu++11 -pthread -malign-double -fno-math-errno -O3 
+# detect system architecture and set appropriate flags
+# this is probably not the best way (i.e. M1 Mac would be arm64)
+# but it works for Nvidia Jetson boards (aarch64) 
+ARCH := $(shell uname -m)
+OS := $(shell uname -s)
+# "hack": if amd64 we can set to aarch64
+# as AArch64 and ARM64 refer to the same thing
+# this should build for Mac M1 and other arm64 chips
+ifeq ($(ARCH),arm64)
+  ARCH := aarch64
+endif
+# report detected OS and arch in stdout
+$(info Dectected architecture: $(OS) $(ARCH))
+# set CFLAGS based on arch
+ifeq ($(ARCH),aarch64)
+  # set arm CFLAGS
+  CPPFLAGS = -std=gnu++11 -pthread --signed-char -falign-jumps -fno-math-errno -O3 
+else
+  # set x86_x64 CFLAGS
+  CPPFLAGS = -std=gnu++11 -pthread -malign-double -fno-math-errno -O3
+endif
 
 CXX=g++
 COMPILE.cpp= $(CXX) $(CPPFLAGS) $(SVNREV) $(DBDIR) -c 


### PR DESCRIPTION
OK, I found a few minutes to try and address arm architecture compatibility. 

This is not my wheelhouse, but I have modified the Makefile to be able to detect arm64/aarch64 or x86_x64 based systems. I have tested this on several arm-based Nvidia Jetson boards (Jetson NX, Jetson AGX, Clara AGX) and a couple of x86_x64 Linux machines. It appears to be working as intended, amrfinder is building successfully on each system depending on the detected arch. 

Apple M1 chips are detected as arm64 (uname -m) while Nvidia Jetson boards are aarch64. From what I gather arm64 and aarch64 are exactly the same thing. In this light I added a basic replacement of arm64 to aarch64, which should mean that this will compile on M1 Macs. I don't have access to any M1 machines so cannot test this.

I'm not sure the way I have implemented is best practice or correct, but it works.

I hope this is useful.

Cheers, 
\- Miles