### PR TITLE
Makefile: add $(DESTDIR) variable to use GNU make's staged Install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,11 +152,11 @@ clean:
 	rm -f $(BINARIES)
 
 install:
-	@if [ ! -e $(bindir) ]; \
+	@if [ ! -e $(DESTDIR)$(bindir) ]; \
 	then \
-		mkdir -p $(bindir); \
+		mkdir -p $(DESTDIR)$(bindir); \
 	fi
-	$(INSTALL) $(BINARIES) $(bindir)
+	$(INSTALL) $(BINARIES) $(DESTDIR)$(bindir)
 
 # amrfinder binaries for github binary release
 GITHUB_FILE=amrfinder_binaries_v$(VERSION_STRING)


### PR DESCRIPTION
i maintain amrfinder binary package on behalf of [Bioarchlinux ](https://github.com/BioArchLinux/Packages )project

gnu make uses $(DESTDIR) variable so that distro packagers can install files to staging directory using `make DESTDIR=${pkgdir} install` which then can be packaged into appropriate package file used by distro

currently we are manually patching [makefile ](https://github.com/BioArchLinux/Packages/blob/d09b38ca07544eaec0febdd40e4bea6ab3661ee5/BioArchLinux/amrfinderplus/destdir.patch) to add $(DESTDIR) variable prior to compiling. this pull request, if merged, will allow us to avoid manual patching in future releases. 