### PR TITLE
Makefile: add linker flags for binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,12 +99,12 @@ alignment.o:	alignment.hpp alignment.hpp common.inc
 amr_report.o:	common.hpp common.inc gff.hpp alignment.hpp
 amr_reportOBJS=amr_report.o common.o gff.o alignment.o
 amr_report:	$(amr_reportOBJS)
-	$(CXX) -o $@ $(amr_reportOBJS)
+	$(CXX) $(LDFLAGS) -o $@ $(amr_reportOBJS)
 
 amrfinder.o:  common.hpp common.inc gff.hpp
 amrfinderOBJS=amrfinder.o common.o gff.o tsv.o
 amrfinder:	$(amrfinderOBJS)
-	$(CXX) -o $@ $(amrfinderOBJS) -pthread $(DBDIR)
+	$(CXX) $(LDFLAGS) -o $@ $(amrfinderOBJS) -pthread $(DBDIR)
 
 amrfinder_update.o:  common.hpp common.inc 
 amrfinder_updateOBJS=amrfinder_update.o common.o curl_easy.o
@@ -113,37 +113,37 @@ amrfinder_update:      $(amrfinder_updateOBJS)
 	then  \
 		touch amrfinder_update.cpp ;\
 	fi # make sure the next make command rebuilds amrfinder_update
-	$(CXX) -o $@ $(amrfinder_updateOBJS) -lcurl 
+	$(CXX) $(LDFLAGS) -o $@ $(amrfinder_updateOBJS) -lcurl 
 
 amrfinder_index.o:  common.hpp common.inc 
 amrfinder_indexOBJS=amrfinder_index.o common.o
 amrfinder_index:      $(amrfinder_indexOBJS) 
-	$(CXX) -o $@ $(amrfinder_indexOBJS) 
+	$(CXX) $(LDFLAGS) -o $@ $(amrfinder_indexOBJS) 
 
 fasta_check.o:	common.hpp common.inc 
 fasta_checkOBJS=fasta_check.o common.o 
 fasta_check:	$(fasta_checkOBJS)
-	$(CXX) -o $@ $(fasta_checkOBJS)
+	$(CXX) $(LDFLAGS) -o $@ $(fasta_checkOBJS)
 
 fasta_extract.o:	common.hpp common.inc
 fasta_extractOBJS=fasta_extract.o common.o
 fasta_extract:	$(fasta_extractOBJS)
-	$(CXX) -o $@ $(fasta_extractOBJS)
+	$(CXX) $(LDFLAGS) -o $@ $(fasta_extractOBJS)
 
 fasta2parts.o:	common.hpp common.inc
 fasta2partsOBJS=fasta2parts.o common.o
 fasta2parts:	$(fasta2partsOBJS)
-	$(CXX) -o $@ $(fasta2partsOBJS)
+	$(CXX) $(LDFLAGS) -o $@ $(fasta2partsOBJS)
 
 gff_check.o:	common.hpp common.inc gff.hpp
 gff_checkOBJS=gff_check.o common.o gff.o
 gff_check:	$(gff_checkOBJS)
-	$(CXX) -o $@ $(gff_checkOBJS)
+	$(CXX) $(LDFLAGS) -o $@ $(gff_checkOBJS)
 
 dna_mutation.o:	common.hpp common.inc alignment.hpp
 dna_mutationOBJS=dna_mutation.o common.o alignment.o
 dna_mutation:	$(dna_mutationOBJS)
-	$(CXX) -o $@ $(dna_mutationOBJS)
+	$(CXX) $(LDFLAGS) -o $@ $(dna_mutationOBJS)
 
 
 


### PR DESCRIPTION
Thanks for merging the PR #131

in additon to ptaching $(DESTDIR) variable we were also patching `$(LDFLAGS)` linker flags into makefile. the binaries generated by unpatched makefile lacked [RELRO](https://wiki.archlinux.org/title/Arch_package_guidelines/Security#RELRO) mitigations. 

```
amrfinderplus W: ELF file ('usr/bin/amr_report') lacks FULL RELRO, check LDFLAGS.
amrfinderplus W: ELF file ('usr/bin/amrfinder') lacks FULL RELRO, check LDFLAGS.
amrfinderplus W: ELF file ('usr/bin/amrfinder_index') lacks FULL RELRO, check LDFLAGS.
amrfinderplus W: ELF file ('usr/bin/amrfinder_update') lacks FULL RELRO, check LDFLAGS.
amrfinderplus W: ELF file ('usr/bin/dna_mutation') lacks FULL RELRO, check LDFLAGS.
amrfinderplus W: ELF file ('usr/bin/fasta2parts') lacks FULL RELRO, check LDFLAGS.
amrfinderplus W: ELF file ('usr/bin/fasta_check') lacks FULL RELRO, check LDFLAGS.
amrfinderplus W: ELF file ('usr/bin/fasta_extract') lacks FULL RELRO, check LDFLAGS.
amrfinderplus W: ELF file ('usr/bin/gff_check') lacks FULL RELRO, check LDFLAGS.

```
Major distros including archlinux strongly encourages RELRO mitigations be applied to binaries. 

Adding `$(LDFLAGS)` to the Makefile will allow binaries to be built using the appropriate linker flags set in the build server environment.

  