### PR TITLE
Fixes for GitHub bioconda action tests

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -44,6 +44,8 @@ jobs:
              -O ${BASE_URL}/test_dna.expected \
              -O ${BASE_URL}/test_dna_mut_all.expected \
              -O ${BASE_URL}/test_prot.expected \
+             -O ${BASE_URL}/test_disrupt.fa \
+             -O ${BASE_URL}/test_disrupt.expected \
              -O ${BASE_URL}/test_amrfinder.sh
     - name: run tests
       run: |
@@ -87,6 +89,8 @@ jobs:
              -O ${BASE_URL}/test_dna.expected \
              -O ${BASE_URL}/test_dna_mut_all.expected \
              -O ${BASE_URL}/test_prot.expected \
+             -O ${BASE_URL}/test_disrupt.fa \
+             -O ${BASE_URL}/test_disrupt.expected \
              -O ${BASE_URL}/test_amrfinder.sh
     - name: run tests
       shell: bash -el {0}

--- a/.github/workflows/mac_conda.yml
+++ b/.github/workflows/mac_conda.yml
@@ -50,6 +50,8 @@ jobs:
              -O ${BASE_URL}/test_dna.expected \
              -O ${BASE_URL}/test_dna_mut_all.expected \
              -O ${BASE_URL}/test_prot.expected \
+             -O ${BASE_URL}/test_disrupt.fa \
+             -O ${BASE_URL}/test_disrupt.expected \
              -O ${BASE_URL}/test_amrfinder.sh
     - name: Run tests
       run: |
@@ -100,6 +102,8 @@ jobs:
              -O ${BASE_URL}/test_dna.expected \
              -O ${BASE_URL}/test_dna_mut_all.expected \
              -O ${BASE_URL}/test_prot.expected \
+             -O ${BASE_URL}/test_disrupt.fa \
+             -O ${BASE_URL}/test_disrupt.expected \
              -O ${BASE_URL}/test_amrfinder.sh
     - name: Run tests
       run: |

--- a/test_amrfinder.sh
+++ b/test_amrfinder.sh
@@ -49,13 +49,18 @@ then
     echo "-n option detected, skipping download of test data"
 else
     echo Downloading fresh test data...
-    curl -k -s -f \
-         -O https://raw.githubusercontent.com/ncbi/amr/master/test_dna.fa \
-         -O https://raw.githubusercontent.com/ncbi/amr/master/test_prot.fa \
-         -O https://raw.githubusercontent.com/ncbi/amr/master/test_prot.gff \
-         -O https://raw.githubusercontent.com/ncbi/amr/master/test_both.expected \
-         -O https://raw.githubusercontent.com/ncbi/amr/master/test_dna.expected \
-         -O https://raw.githubusercontent.com/ncbi/amr/master/test_prot.expected
+    BASE_URL=https://raw.githubusercontent.com/ncbi/amr/master
+    curl --silent -L \
+       -O ${BASE_URL}/test_dna.fa \
+       -O ${BASE_URL}/test_prot.fa \
+       -O ${BASE_URL}/test_prot.gff \
+       -O ${BASE_URL}/test_both.expected \
+       -O ${BASE_URL}/test_dna.expected \
+       -O ${BASE_URL}/test_dna_mut_all.expected \
+       -O ${BASE_URL}/test_prot.expected \
+       -O ${BASE_URL}/test_disrupt.fa \
+       -O ${BASE_URL}/test_disrupt.expected
+
 
     if [ $? != 0 ]
     then


### PR DESCRIPTION
New test added for https://github.com/ncbi/amr/issues/174 / version 4.2.5 broke bioconda tests. This fixes them.